### PR TITLE
Fix 403 error on presence channel authentication

### DIFF
--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -21,6 +21,18 @@ if (import.meta.env.VITE_BROADCAST_CONNECTION === 'pusher') {
         cluster: import.meta.env.VITE_PUSHER_APP_CLUSTER,
         forceTLS: import.meta.env.VITE_PUSHER_SCHEME === 'https',
         enableLogging: import.meta.env.DEV,
+        authorizer: (channel, options) => ({
+            authorize: (socketId, callback) => {
+                axios.post('/broadcasting/auth', {
+                    socket_id: socketId,
+                    channel_name: channel.name,
+                }, {
+                    withCredentials: true,
+                })
+                    .then(response => callback(null, response.data))
+                    .catch(error => callback(error));
+            },
+        }),
     });
 } else {
     window.Echo = new Echo({
@@ -32,6 +44,18 @@ if (import.meta.env.VITE_BROADCAST_CONNECTION === 'pusher') {
         forceTLS: (import.meta.env.VITE_REVERB_SCHEME ?? 'https') === 'https',
         enabledTransports: ['ws', 'wss'],
         enableLogging: import.meta.env.DEV,
+        authorizer: (channel, options) => ({
+            authorize: (socketId, callback) => {
+                axios.post('/broadcasting/auth', {
+                    socket_id: socketId,
+                    channel_name: channel.name,
+                }, {
+                    withCredentials: true,
+                })
+                    .then(response => callback(null, response.data))
+                    .catch(error => callback(error));
+            },
+        }),
     });
 }
 

--- a/resources/views/livewire/room.blade.php
+++ b/resources/views/livewire/room.blade.php
@@ -852,6 +852,10 @@ new class extends Component {
                 })
                 .leaving((member) => {
                     $wire.presenceLeaving({ id: member.id, name: member.name, is_spectator: member.is_spectator });
+                })
+                .error((error) => {
+                    console.warn('Presence channel auth failed:', error);
+                    // Fallback: rely on last_seen_at for online status
                 });
         },
         destroy() {

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -19,6 +19,12 @@ Broadcast::channel('presence-room.{slug}', function (mixed $user, string $slug) 
     // Since we don't use authentication, $user may be null
     // We authorize based on session and return participant info
     unset($user); // Not used - app is session-based
+
+    // Ensure session is started
+    if (! session()->isStarted()) {
+        session()->start();
+    }
+
     $sessionId = session()->getId();
 
     $participant = Participant::whereHas('room', fn ($q) => $q->where('slug', $slug))
@@ -26,6 +32,9 @@ Broadcast::channel('presence-room.{slug}', function (mixed $user, string $slug) 
         ->first();
 
     if ($participant) {
+        // Update last seen timestamp
+        $participant->updateLastSeen();
+
         return [
             'id' => $participant->id,
             'name' => $participant->name,


### PR DESCRIPTION
- Add custom authorizer with withCredentials to ensure session cookies are sent with broadcasting auth requests
- Ensure session is started before accessing session ID in channel auth
- Update last_seen_at when participant authenticates to presence channel
- Add error handler for graceful fallback when presence auth fails